### PR TITLE
Fix Gog and HumbleBundle when installed to /Applications

### DIFF
--- a/Fix Spacechem.app/Contents/Resources/script
+++ b/Fix Spacechem.app/Contents/Resources/script
@@ -2,12 +2,15 @@
 
 export SPACECHEM_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SpaceChem/SpaceChem.app/Contents"
 
+# Check GOG app at /Applications
+if [ ! -d "$SPACECHEM_PATH" ]; then
+	export SPACECHEM_PATH="/Applications/Spacechem.app/Contents/Resources/SpaceChem.app/Contents"
+fi
+
 # Not in the Steam library? Try the system application folder (Humble Bundle version could have been installed there)
 if [ ! -d "$SPACECHEM_PATH" ]; then
 	export SPACECHEM_PATH="/Applications/SpaceChem.app/Contents"
 fi
-# Should probably check the GOG library for that version, but I don't know the correct path for it
-
 
 if [ ! -d "$SPACECHEM_PATH" ]; then
   echo "I couldn't find SpaceChem! Is it installed in the default Steam library or the default Application folder?"

--- a/Fix Spacechem.app/Contents/Resources/script
+++ b/Fix Spacechem.app/Contents/Resources/script
@@ -2,8 +2,15 @@
 
 export SPACECHEM_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SpaceChem/SpaceChem.app/Contents"
 
+# Not in the Steam library? Try the system application folder (Humble Bundle version could have been installed there)
 if [ ! -d "$SPACECHEM_PATH" ]; then
-  echo "I couldn't find SpaceChem! Is it installed in the default Steam library?"
+	export SPACECHEM_PATH="/Applications/SpaceChem.app/Contents"
+fi
+# Should probably check the GOG library for that version, but I don't know the correct path for it
+
+
+if [ ! -d "$SPACECHEM_PATH" ]; then
+  echo "I couldn't find SpaceChem! Is it installed in the default Steam library or the default Application folder?"
   read -p "Press Return to exit."
   exit 1
 fi
@@ -16,8 +23,14 @@ rm -rf Frameworks/SDL.framework
 tar -jxvf bonsai.tar.bz2
 rm bonsai.tar.bz2
 
-echo "Should all be OK! Try launching via Steam. Any problems, log an issue on GitHub."
+# Fix broken symbolic link in bonsai
+pushd Frameworks/SDL_mixer.framework
+rm SDL_mixer.framework
+ln -s Versions/A/SDL_mixer .
+popd
+# End fix for broken symlink
+
+echo "Should all be OK! Try launching as usual. Any problems, log an issue on GitHub."
 echo "(And copy and paste this log in the issue.)"
 
 read -p "Press Return to close..."
-

--- a/fix-spacechem.sh
+++ b/fix-spacechem.sh
@@ -2,12 +2,15 @@
 
 export SPACECHEM_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SpaceChem/SpaceChem.app/Contents"
 
+# Check GOG app at /Applications
+if [ ! -d "$SPACECHEM_PATH" ]; then
+	export SPACECHEM_PATH="/Applications/Spacechem.app/Contents/Resources/SpaceChem.app/Contents"
+fi
+
 # Not in the Steam library? Try the system application folder (Humble Bundle version could have been installed there)
 if [ ! -d "$SPACECHEM_PATH" ]; then
 	export SPACECHEM_PATH="/Applications/SpaceChem.app/Contents"
 fi
-# Should probably check the GOG library for that version, but I don't know the correct path for it
-
 
 if [ ! -d "$SPACECHEM_PATH" ]; then
   echo "I couldn't find SpaceChem! Is it installed in the default Steam library or the default Application folder?"

--- a/fix-spacechem.sh
+++ b/fix-spacechem.sh
@@ -2,8 +2,15 @@
 
 export SPACECHEM_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SpaceChem/SpaceChem.app/Contents"
 
+# Not in the Steam library? Try the system application folder (Humble Bundle version could have been installed there)
 if [ ! -d "$SPACECHEM_PATH" ]; then
-  echo "I couldn't find SpaceChem! Is it installed in the default Steam library?"
+	export SPACECHEM_PATH="/Applications/SpaceChem.app/Contents"
+fi
+# Should probably check the GOG library for that version, but I don't know the correct path for it
+
+
+if [ ! -d "$SPACECHEM_PATH" ]; then
+  echo "I couldn't find SpaceChem! Is it installed in the default Steam library or the default Application folder?"
   read -p "Press Return to exit."
   exit 1
 fi
@@ -16,8 +23,14 @@ rm -rf Frameworks/SDL.framework
 tar -jxvf bonsai.tar.bz2
 rm bonsai.tar.bz2
 
-echo "Should all be OK! Try launching via Steam. Any problems, log an issue on GitHub."
+# Fix broken symbolic link in bonsai
+pushd Frameworks/SDL_mixer.framework
+rm SDL_mixer.framework
+ln -s Versions/A/SDL_mixer .
+popd
+# End fix for broken symlink
+
+echo "Should all be OK! Try launching as usual. Any problems, log an issue on GitHub."
 echo "(And copy and paste this log in the issue.)"
 
 read -p "Press Return to close..."
-


### PR DESCRIPTION
Checks two additional paths and fixes symlink in bonsai.tar.bz2